### PR TITLE
Convert args to type string

### DIFF
--- a/bsub/bsub.py
+++ b/bsub/bsub.py
@@ -261,7 +261,7 @@ class bsub(object):
         """
         kargs = cls._kwargs_to_flag_string(kwargs)
         if all(isinstance(a, six.integer_types) for a in args):
-            command = "bkill " + kargs + " " + " ".join(args)
+            command = "bkill " + kargs + " " + " ".join(str(a) for a in args)
             _run(command, "is being terminated")
         else:
             for a in args:


### PR DESCRIPTION
When calling `kill` on a bsub object, `bsub.job_id` (an integer type) is passed to `*args`. In these scenarios, `*args` must be converted to type string.