### PR TITLE
solve attribute error when calling remove on frozenset

### DIFF
--- a/bsub/bsub.py
+++ b/bsub/bsub.py
@@ -149,7 +149,7 @@ class bsub(object):
 
             if len(job_ids) == []:
                 return
-            job_ids = frozenset(job_ids)
+            job_ids = set(job_ids)
             sleep_time = 1
             while job_ids:
                 for job in job_ids.intersection(set(self.completed_jobs(names=names))):


### PR DESCRIPTION
Fixes AttributeError exception thrown when calling remove on job_ids since frozenset does not have "remove" method.